### PR TITLE
JWK Support

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -6,6 +6,7 @@ dependencyManagement {
 
 	dependencies {
 		dependency 'com.auth0:java-jwt:3.3.0'
+		dependency 'com.squareup.okhttp3:mockwebserver:3.7.0'
 		dependency 'commons-io:commons-io:2.6'
 		dependency 'javax.servlet:javax.servlet-api:4.0.0'
 		dependency 'junit:junit:4.12'

--- a/oauth2/oauth2-resource-server/spring-security-oauth2-resource-server.gradle
+++ b/oauth2/oauth2-resource-server/spring-security-oauth2-resource-server.gradle
@@ -6,4 +6,9 @@ dependencies {
 	compile 'org.springframework.security:spring-security-web'
 
 	compile 'javax.servlet:javax.servlet-api'
+
+	testCompile 'org.springframework.security:spring-security-test'
+	testCompile 'org.springframework:spring-webmvc'
+
+	testCompile 'com.squareup.okhttp3:mockwebserver'
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/resourceserver/ResourceServerConfigurerTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/resourceserver/ResourceServerConfigurerTests.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.config.annotation.web.configurers.oauth2.resourceserver;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.jose.jwk.JwkSetBuilder;
+import org.springframework.security.oauth2.jose.jws.JwsBuilder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+import org.springframework.security.oauth2.resourceserver.authentication.JwtEncodedOAuth2AccessTokenAuthenticationProvider;
+import org.springframework.security.oauth2.resourceserver.web.BearerTokenAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Josh Cummings
+ */
+public class ResourceServerConfigurerTests {
+
+	private AnnotationConfigWebApplicationContext context;
+
+	private MockMvc mvc;
+	private MockWebServer server;
+
+	@Test
+	public void performWhenBearerIsSignedWithJwkOverRsaThenAccessIsAuthorized()
+			throws Exception {
+
+		this.register(WebServerConfig.class, RsaConfig.class);
+
+		JwkSetBuilder good = JwkSetBuilder.withRsa("good");
+
+		String authority = JwsBuilder.withAlgorithm("RS256")
+				.expiresAt(Instant.now().plus(1, ChronoUnit.HOURS))
+				.scope("permission.read")
+				.signWithAny(good).build();
+
+		this.setupJwks(good);
+
+		this.mvc.perform(bearer(get("/"), authority))
+				.andExpect(content().string("OK"));
+
+		assertThat(this.server.getRequestCount()).isEqualTo(1);
+	}
+
+	@Test
+	public void performWhenBearerIsSignedWithMissingJwkOverRsaThenNotAuthorized()
+			throws Exception {
+
+		this.register(WebServerConfig.class, RsaConfig.class);
+
+		JwkSetBuilder bad = JwkSetBuilder.withRsa("bad");
+		JwkSetBuilder good = JwkSetBuilder.withRsa("good");
+
+		String authority = JwsBuilder.withAlgorithm("RS256").signWithAny(bad).build();
+
+		this.setupJwks(good);
+
+		this.mvc.perform(bearer(get("/"), authority))
+				.andExpect(status().isUnauthorized());
+
+		assertThat(this.server.getRequestCount()).isEqualTo(2);
+	}
+
+	@Test
+	public void performWhenBearerIsSignedButServerHasNoJwksThenNotAuthorized()
+			throws Exception {
+
+		this.register(WebServerConfig.class, RsaConfig.class);
+
+		JwkSetBuilder empty = JwkSetBuilder.empty();
+		JwkSetBuilder good = JwkSetBuilder.withRsa("good");
+
+		String authority = JwsBuilder.withAlgorithm("RS256").signWithAny(good).build();
+
+		this.setupJwks(empty);
+
+		this.mvc.perform(bearer(get("/"), authority))
+				.andExpect(status().isUnauthorized());
+
+		assertThat(this.server.getRequestCount()).isEqualTo(2);
+	}
+
+	@EnableWebSecurity
+	public static class RsaConfig extends WithResourceServerConfigurerAdapter {
+		@Autowired
+		MockWebServer server;
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			super.configure(http);
+
+			http
+					.authorizeRequests().anyRequest()
+					.access("authentication.hasClaim('scope', 'permission.read')");
+		}
+
+		@Bean
+		protected AuthenticationProvider oauth2AuthenticationProvider() {
+			return new JwtEncodedOAuth2AccessTokenAuthenticationProvider(this.jwtDecoder());
+		}
+
+		@Bean
+		JwtDecoder jwtDecoder() {
+			HttpUrl url = this.server.url("/.well-known/jwks.json");
+
+			return new NimbusJwtDecoderJwkSupport(
+					url.toString(),
+					"RS256");
+		}
+
+	}
+
+	@Test
+	public void performWhenBearerIsSignedWithJwkOverEcdsaThenAuthorized()
+			throws Exception {
+
+		this.register(WebServerConfig.class, EcConfig.class);
+
+		JwkSetBuilder good = JwkSetBuilder.withEc("good");
+
+		String authority = JwsBuilder.withAlgorithm("ES512")
+				.expiresAt(Instant.now().plus(1, ChronoUnit.HOURS))
+				.scope("permission.read")
+				.signWithAny(good).build();
+
+		this.setupJwks(good);
+
+		this.mvc.perform(bearer(get("/"), authority))
+				.andExpect(content().string("OK"));
+
+		assertThat(this.server.getRequestCount()).isEqualTo(1);
+	}
+
+	@EnableWebSecurity
+	public static class EcConfig extends WithResourceServerConfigurerAdapter {
+		@Autowired MockWebServer server;
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			super.configure(http);
+
+			http
+					.authorizeRequests().anyRequest()
+					.access("authentication.hasClaim('scope', 'permission.read')");
+		}
+
+		@Bean
+		protected AuthenticationProvider oauth2AuthenticationProvider() {
+			return new JwtEncodedOAuth2AccessTokenAuthenticationProvider(this.jwtDecoder());
+		}
+
+		@Bean
+		JwtDecoder jwtDecoder() {
+			HttpUrl url = this.server.url("/.well-known/jwks.json");
+
+			return new NimbusJwtDecoderJwkSupport(
+					url.toString(),
+					"ES512");
+		}
+
+	}
+
+	public static abstract class WithResourceServerConfigurerAdapter extends WebSecurityConfigurerAdapter {
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.addFilterAfter(
+							new BearerTokenAuthenticationFilter(authenticationManager()),
+							BasicAuthenticationFilter.class)
+					.authenticationProvider(oauth2AuthenticationProvider())
+					.exceptionHandling().and()
+					.csrf().disable();
+		}
+
+		protected abstract AuthenticationProvider oauth2AuthenticationProvider();
+	}
+
+	@Configuration
+	public static class WebServerConfig {
+		@RestController
+		public class SecuredController {
+			@GetMapping("/")
+			public String ok() {
+				return "OK";
+			}
+		}
+
+		@Bean
+		MockWebServer server() {
+			return new MockWebServer();
+		}
+	}
+
+	private MockHttpServletRequestBuilder bearer(MockHttpServletRequestBuilder mock, String authority) {
+		return mock.header("Authorization", "Bearer " + authority);
+	}
+
+	private void setupJwks(JwkSetBuilder builder) {
+			MockResponse response = new MockResponse()
+					.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+					.setBody(builder.build());
+
+			this.server.enqueue(response);
+		this.server.enqueue(response);
+
+	}
+
+	private void register(Class<?>... classes) {
+		this.context = new AnnotationConfigWebApplicationContext();
+		this.context.register(classes);
+		this.context.setServletContext(new MockServletContext());
+		this.context.setServletConfig(new MockServletConfig());
+		this.context.refresh();
+		this.mvc = MockMvcBuilders.webAppContextSetup(this.context)
+				.apply(springSecurity()).build();
+
+		this.server = this.context.getBean(MockWebServer.class);
+	}
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/jose/jwk/JwkSetBuilder.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/jose/jwk/JwkSetBuilder.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.jose.jwk;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.AsymmetricJWK;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.SecretJWK;
+import net.minidev.json.JSONObject;
+
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A convenience class for working with Nimbus's {@link JWK} API.
+ *
+ * @author Josh Cummings
+ */
+public class JwkSetBuilder {
+	private final Map<String, JWK> jwks;
+
+	private JwkSetBuilder() {
+		this.jwks = new LinkedHashMap<>();
+	}
+
+	/**
+	 * Generate an empty JWK set
+	 */
+	public static JwkSetBuilder empty() {
+		return new JwkSetBuilder();
+	}
+
+	/**
+	 * Generate an EC JWK, adding it to the list of available JWKs
+	 *
+	 * @param keyId
+	 * @return
+	 */
+	public static JwkSetBuilder withEc(String keyId) {
+		JwkSetBuilder set = new JwkSetBuilder();
+
+		try {
+			KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+			generator.initialize(521); // yes, 521
+			KeyPair keyPair = generator.generateKeyPair();
+
+			ECKey key = new ECKey.Builder(Curve.P_521, ((ECPublicKey) keyPair.getPublic()))
+					.privateKey(keyPair.getPrivate())
+					.keyID(keyId)
+					.build();
+
+			set.jwks.put(keyId, key);
+			return set;
+		} catch ( NoSuchAlgorithmException ecMissing ) {
+			throw new IllegalStateException(ecMissing);
+		}
+	}
+
+	/**
+	 * Generate an RSA JWK, adding it to the list of available JWKs.
+	 *
+	 * @param keyId
+	 * @return
+	 */
+	public static JwkSetBuilder withRsa(String keyId) {
+		JwkSetBuilder set = new JwkSetBuilder();
+
+		try {
+			KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+			generator.initialize(2048);
+			KeyPair kp = generator.generateKeyPair();
+
+			RSAKey key = new RSAKey.Builder((RSAPublicKey) kp.getPublic())
+					.privateKey(kp.getPrivate())
+					.keyID(keyId)
+					.build();
+
+			set.jwks.put(keyId, key);
+
+			return set;
+		} catch ( NoSuchAlgorithmException rsaMissing ) {
+			throw new IllegalStateException(rsaMissing);
+		}
+	}
+
+	/**
+	 * Look up JWK by {@code keyId}
+	 * @param keyId
+	 * @return
+	 */
+	public Key getKeyById(String keyId) {
+		return this.extractKey(this.jwks.get(keyId));
+	}
+
+	/**
+	 * Extract kid and key from the JWKs already configured
+	 *
+	 * @return
+	 */
+	public Map<String, Key> getKeyMap() {
+		return
+				this.jwks.entrySet().stream()
+					.collect(Collectors.toMap(Map.Entry::getKey,
+												e -> this.extractKey(e.getValue())));
+	}
+
+	/**
+	 * Convert the list into a JWK json set, the format being compatible
+	 * with the expected response of a JWK set url.
+	 *
+	 * @return
+	 */
+	public String build() {
+		return new JSONObject()
+				.appendField("keys", this.jwks.values()).toJSONString();
+	}
+
+	private Key extractKey(JWK jwk) {
+		try {
+			if ( jwk instanceof AsymmetricJWK ) {
+				return ((AsymmetricJWK) jwk).toPrivateKey();
+			} else if ( jwk instanceof SecretJWK ){
+				return ((SecretJWK) jwk).toSecretKey();
+			} else {
+				return null;
+			}
+		} catch ( JOSEException failed ) {
+			throw new IllegalArgumentException(failed);
+		}
+	}
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/jose/jws/JwsBuilder.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/jose/jws/JwsBuilder.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.jose.jws;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import net.minidev.json.JSONObject;
+import org.springframework.security.oauth2.jose.jwk.JwkSetBuilder;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A convenience class for working with Nimbus's {@link JWSObject} API
+ *
+ * @author Josh Cummings
+ */
+public class JwsBuilder {
+	private JWSHeader.Builder header;
+	private JSONObject payload = new JSONObject();
+	private Set<String> scope = new LinkedHashSet<>();
+
+	private JWSObject jws;
+
+	private JwsBuilder(String algorithm) {
+		JWSAlgorithm alg = JWSAlgorithm.parse(algorithm);
+		this.header = new JWSHeader.Builder(alg);
+	}
+
+	/**
+	 * Instantiate a JwsBuilder with the given {@code algorithm}
+	 *
+	 * @param algorithm
+	 * @return
+	 */
+	public static JwsBuilder withAlgorithm(String algorithm) {
+		return new JwsBuilder(algorithm);
+	}
+
+	/**
+	 * Add or update a field to the payload of the JWT
+	 *
+	 * @param name
+	 * @param value
+	 * @return
+	 */
+	public JwsBuilder claim(String name, Object value) {
+		this.payload.appendField(name, value);
+		return this;
+	}
+
+	/**
+	 * Set the 'exp' field on the JWT
+	 *
+	 * @param expiresAt
+	 * @return
+	 */
+	public JwsBuilder expiresAt(Instant expiresAt) {
+		this.payload.appendField(JwtClaimNames.EXP, expiresAt.getEpochSecond());
+		return this;
+	}
+
+	/**
+	 * Append to the 'scope' field on the JWT
+	 *
+	 * @param scope
+	 * @return
+	 */
+	public JwsBuilder scope(String scope) {
+		this.scope.add(scope);
+		return this;
+	}
+
+	/**
+	 * Sign the JWT with any valid JWK in the provided JWK set
+	 *
+	 * Note that this method is deterministic. Given the same JWK set, it will always
+	 * pick the same JWK across multiple invocations in the same runtime.
+	 *
+	 * Also note that this method should only be used when the test genuinely does not
+	 * care which JWK is chosen.
+	 *
+	 * @param builder - the JWK set to use
+	 *
+	 * @return
+	 */
+	public JwsBuilder signWithAny(JwkSetBuilder builder) {
+		Map<String, Key> keys = builder.getKeyMap();
+
+		if ( keys.isEmpty() ) {
+			throw new IllegalStateException("no keys configured in provided JwkSetBuilder");
+		} else {
+			Map.Entry<String, Key> entry = keys.entrySet().iterator().next();
+			return sign(entry.getKey(), entry.getValue());
+		}
+	}
+
+	/**
+	 * Sign the JWT with the given kid and JWK set
+	 *
+	 * @param keyId
+	 * @param builder - A JWK set containing an JWK with key {@code keyId}
+	 * @return
+	 */
+	public JwsBuilder sign(String keyId, JwkSetBuilder builder) {
+		return sign(keyId, builder.getKeyById(keyId));
+	}
+
+	/**
+	 * Sign the JWT with the given kid and key
+	 *
+	 * @param keyId
+	 * @return
+	 */
+	public JwsBuilder sign(String keyId, Key key) {
+		this.claim("scope", this.scope.stream().collect(Collectors.joining(" ")));
+
+		this.jws =
+				new JWSObject(
+						this.header.keyID(keyId).build(),
+						new Payload(this.payload)
+				);
+
+		try {
+			if ( key instanceof RSAPrivateKey ) {
+				this.jws.sign(new RSASSASigner((RSAPrivateKey) key));
+			} else if ( key instanceof ECPrivateKey ) {
+				this.jws.sign(new ECDSASigner((ECPrivateKey) key));
+			} else if ( key instanceof SecretKey ) {
+				this.jws.sign(new MACSigner((SecretKey) key));
+			}
+		} catch ( JOSEException jex ) {
+			throw new IllegalArgumentException(jex);
+		}
+
+		return this;
+	}
+
+
+	/**
+	 * Build the JWT
+	 *
+	 * @return
+	 */
+	public String build() {
+		if ( this.jws == null ) {
+			throw new IllegalStateException("attempted to serialize an unsigned JWT");
+		}
+
+		return this.jws.serialize();
+	}
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/authentication/JwtEncodedOAuth2AccessTokenAuthenticationProviderTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/authentication/JwtEncodedOAuth2AccessTokenAuthenticationProviderTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.resourceserver.authentication;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.bearer.OAuth2AccessTokenAuthority;
+import org.springframework.security.oauth2.jwt.AccessTokenJwtVerifier;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link JwtEncodedOAuth2AccessTokenAuthenticationProvider}
+ *
+ * @author Josh Cummings
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JwtEncodedOAuth2AccessTokenAuthenticationProviderTests {
+	@Mock
+	JwtDecoder jwtDecoder;
+
+	@Mock
+	AccessTokenJwtVerifier jwtVerifier;
+
+	@Mock
+	Jwt jwt;
+
+	@InjectMocks
+	JwtEncodedOAuth2AccessTokenAuthenticationProvider provider;
+
+	@Test
+	public void authenticateWhenJwtDecodesThenAuthenticationHasAttributesContainedInJwt() {
+		OAuth2ResourceAuthenticationToken token = this.authentication();
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("name", "value");
+
+		when(this.jwtDecoder.decode("token")).thenReturn(this.jwt);
+		when(this.jwt.getClaims()).thenReturn(claims);
+
+		token = (OAuth2ResourceAuthenticationToken) this.provider.authenticate(token);
+
+		assertThat(token.getAuthorities().iterator().next()).isInstanceOf(OAuth2AccessTokenAuthority.class);
+		assertThat(token.hasClaim("name", "value")).isTrue();
+	}
+
+	@Test
+	public void authenticateWhenJwtDecodeFailsThenRespondsWithInvalidRequest() {
+		OAuth2ResourceAuthenticationToken token = this.authentication();
+
+		when(this.jwtDecoder.decode("token")).thenThrow(JwtException.class);
+
+		assertThatThrownBy(() -> this.provider.authenticate(token))
+				.matches(failed -> failed instanceof OAuth2AuthenticationException)
+				.matches(errorCode(OAuth2ErrorCodes.INVALID_REQUEST));
+	}
+
+	@Test
+	public void authenticateWhenJwtVerifierFailsThenResponseWithInvalidRequest() {
+		OAuth2ResourceAuthenticationToken token = this.authentication();
+
+		doThrow(JwtException.class).when(this.jwtVerifier).verifyClaims(null);
+
+		assertThatThrownBy(() -> this.provider.authenticate(token))
+				.matches(failed -> failed instanceof OAuth2AuthenticationException)
+				.matches(errorCode(OAuth2ErrorCodes.INVALID_REQUEST));
+	}
+
+	@Test
+	public void authenticateWhenAuthoritiesMappedThenAuthenticationHasMappedAuthorities() {
+		GrantedAuthoritiesMapper mapper = (authorities) -> {
+			SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER");
+			List<GrantedAuthority> composite = new ArrayList<>(authorities);
+			composite.add(0, authority);
+			return composite;
+		};
+
+		this.provider.setAuthoritiesMapper(mapper);
+
+		OAuth2ResourceAuthenticationToken token = this.authentication();
+
+		when(this.jwtDecoder.decode("token")).thenReturn(this.jwt);
+		when(this.jwt.getClaims()).thenReturn(new HashMap<>());
+
+		token = (OAuth2ResourceAuthenticationToken) this.provider.authenticate(token);
+
+		assertThat(token.getAuthorities().iterator().next()).isInstanceOf(SimpleGrantedAuthority.class);
+	}
+
+	@Test
+	public void authenticateWhenTokenNotSupportedThenAbstains() {
+		UsernamePasswordAuthenticationToken unsupported =
+				new UsernamePasswordAuthenticationToken("principal", "credentials");
+
+		assertThat(this.provider.authenticate(unsupported)).isNull();
+	}
+
+	private OAuth2ResourceAuthenticationToken authentication() {
+		return new OAuth2ResourceAuthenticationToken("token");
+	}
+
+	private Predicate<? super Throwable> errorCode(String errorCode) {
+		return failed ->
+				((OAuth2AuthenticationException) failed).getError().getErrorCode() == errorCode;
+	}
+}


### PR DESCRIPTION
This commit proves Resource Server's existing support for JWT
validation using a JWK set url as already supported by
NimbusJwtDecoderJwkSupport.

No functionality is added to support this feature as it was already
available through components development for OAuth2 Client.

Issue: spring-projects/spring-security#5130