### PR TITLE
Polish BearerTokenAuthenticationEntryPoint

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/resourceserver/web/BearerTokenAuthenticationEntryPoint.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/resourceserver/web/BearerTokenAuthenticationEntryPoint.java
@@ -16,20 +16,19 @@
 
 package org.springframework.security.oauth2.resourceserver.web;
 
-import java.io.IOException;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.resourceserver.BearerTokenAuthenticationException;
 import org.springframework.security.oauth2.resourceserver.BearerTokenError;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.util.Assert;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * An {@link AuthenticationEntryPoint} implementation used to commence authentication of protected resource requests
@@ -83,7 +82,7 @@ public class BearerTokenAuthenticationEntryPoint implements AuthenticationEntryP
 					.map(attribute -> attribute.getKey() + "=\"" + attribute.getValue() + "\"")
 					.collect(Collectors.joining(", ", " ", ""));
 		}
-		response.addHeader("WWW-Authenticate", wwwAuthenticate);
+		response.addHeader(HttpHeaders.WWW_AUTHENTICATE, wwwAuthenticate);
 		response.sendError(httpStatus.value(), httpStatus.getReasonPhrase());
 	}
 
@@ -92,7 +91,6 @@ public class BearerTokenAuthenticationEntryPoint implements AuthenticationEntryP
 	 * @param realmName the realm name
 	 */
 	public void setRealmName(String realmName) {
-		Assert.hasText(realmName, "realmName must not be null");
 		this.realmName = realmName;
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/web/BearerTokenAuthenticationEntryPointTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/web/BearerTokenAuthenticationEntryPointTests.java
@@ -16,11 +16,8 @@
 
 package org.springframework.security.oauth2.resourceserver.web;
 
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -29,8 +26,10 @@ import org.springframework.security.oauth2.resourceserver.BearerTokenAuthenticat
 import org.springframework.security.oauth2.resourceserver.BearerTokenError;
 import org.springframework.security.oauth2.resourceserver.BearerTokenErrorCodes;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Tests for {@link BearerTokenAuthenticationEntryPoint}.
@@ -172,9 +171,9 @@ public class BearerTokenAuthenticationEntryPointTests {
 	}
 
 	@Test
-	public void setRealmNameWhenNullRealmNameThenIllegalArgumentException() {
-		assertThatThrownBy(() -> this.authenticationEntryPoint.setRealmName(null))
-				.isInstanceOf(IllegalArgumentException.class).hasMessage("realmName must not be null");
+	public void setRealmNameWhenNullRealmNameThenNoExceptionThrown() {
+		assertThatCode(() -> this.authenticationEntryPoint.setRealmName(null))
+				.doesNotThrowAnyException();
 	}
 
 }


### PR DESCRIPTION
There were a couple of comments that were missed in the PR merge,
namely one from @jzheaux regarding setRealmName and one from
@jgrandja regarding OAuth2ParameterNames usage.

Issue spring-projects/spring-security#5125