### PR TITLE
OAuth2Verifier Contract

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/core/OAuth2TokenVerifier.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/core/OAuth2TokenVerifier.java
@@ -15,23 +15,22 @@
  */
 package org.springframework.security.oauth2.core;
 
-import java.util.Map;
-
 /**
  * Implementations of this interface are responsible for &quot;verifying&quot;
  * the validity and/or constraints of the attributes contained in an OAuth 2.0 Token.
  *
  * @author Joe Grandja
+ * @author Josh Cummings
  * @since 5.1
  */
-public interface OAuth2TokenVerifier {
+public interface OAuth2TokenVerifier<T extends AbstractOAuth2Token> {
 
 	/**
-	 * Verify the validity and/or constraints of the provided OAuth 2.0 Token attributes.
+	 * Verify the validity and/or constraints of the provided OAuth 2.0 Token.
 	 *
-	 * @param tokenAttributes a {@code Map} of the token attributes
+	 * @param token an OAuth 2.0 token
 	 * @throws OAuth2AuthenticationException if an error occurs while attempting to verify the token attributes
 	 */
-	void verify(Map<String, Object> tokenAttributes) throws OAuth2AuthenticationException;
+	void verify(T token) throws OAuth2AuthenticationException;
 
 }

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenAuthenticationProvider.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenAuthenticationProvider.java
@@ -76,7 +76,7 @@ public class JwtAccessTokenAuthenticationProvider implements AuthenticationProvi
 			throw new OAuth2AuthenticationException(invalidRequest, failed);
 		}
 
-		this.jwtVerifier.verify(jwt.getClaims());
+		this.jwtVerifier.verify(jwt);
 
 		return new JwtAccessTokenAuthenticationToken(jwt);
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenAuthenticationProviderTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenAuthenticationProviderTests.java
@@ -33,7 +33,6 @@ import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -87,7 +86,7 @@ public class JwtAccessTokenAuthenticationProviderTests {
 		PreAuthenticatedAuthenticationToken token = this.authentication();
 
 		when(this.jwtDecoder.decode("token")).thenReturn(this.jwt);
-		doThrow(OAuth2AuthenticationException.class).when(this.jwtVerifier).verify(anyMap());
+		doThrow(OAuth2AuthenticationException.class).when(this.jwtVerifier).verify(this.jwt);
 
 		assertThatThrownBy(() -> this.provider.authenticate(token))
 				.isInstanceOf(OAuth2AuthenticationException.class);

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenVerifierTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenVerifierTests.java
@@ -42,7 +42,7 @@ public class JwtAccessTokenVerifierTests {
 
 		JwtAccessTokenVerifier verifier = new JwtAccessTokenVerifier();
 
-		assertThatThrownBy(() -> verifier.verify(jwt.getClaims()))
+		assertThatThrownBy(() -> verifier.verify(jwt))
 				.hasMessageContaining("Jwt expired at " + expiry);
 	}
 
@@ -59,7 +59,7 @@ public class JwtAccessTokenVerifierTests {
 
 		JwtAccessTokenVerifier verifier = new JwtAccessTokenVerifier();
 
-		assertThatThrownBy(() -> verifier.verify(jwt.getClaims()))
+		assertThatThrownBy(() -> verifier.verify(jwt))
 				.hasMessageContaining("Jwt used before " + oneHourFromNow);
 	}
 }


### PR DESCRIPTION
Changing the OAuth2Verifier contract to take a token type instead of
simply a Map of attributes. Stronger typing will allow more
expressiveness and make for a contract that is easier to enforce and
evolve.

Fixes: gh-19