### PR TITLE
Fix Error Message Formatting

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenVerifier.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenVerifier.java
@@ -83,7 +83,7 @@ public class JwtAccessTokenVerifier implements OAuth2TokenVerifier {
 			if ( Instant.now().isAfter(expiry.plus(maxClockSkew)) ) {
 				OAuth2Error invalidRequest = new OAuth2Error(
 						OAuth2ErrorCodes.INVALID_REQUEST,
-						String.format("Jwt expired at {}", jwtClaimAccessor.getExpiresAt()),
+						String.format("Jwt expired at %s", jwtClaimAccessor.getExpiresAt()),
 						null);
 				throw new OAuth2AuthenticationException(invalidRequest, invalidRequest.toString());
 			}
@@ -95,7 +95,7 @@ public class JwtAccessTokenVerifier implements OAuth2TokenVerifier {
 			if ( Instant.now().isBefore(notBefore.minus(maxClockSkew)) ) {
 				OAuth2Error invalidRequest = new OAuth2Error(
 						OAuth2ErrorCodes.INVALID_REQUEST,
-						String.format("Jwt used before {}", jwtClaimAccessor.getNotBefore()),
+						String.format("Jwt used before %s", jwtClaimAccessor.getNotBefore()),
 						null);
 				throw new OAuth2AuthenticationException(invalidRequest, invalidRequest.toString());
 			}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenVerifierTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/resourceserver/authentication/JwtAccessTokenVerifierTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.resourceserver.authentication;
+
+import org.assertj.core.util.Maps;
+import org.junit.Test;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Josh Cummings
+ */
+public class JwtAccessTokenVerifierTests {
+	@Test
+	public void verifyWhenJwtIsExpiredThenErrorMessageIndicatesExpirationTime() {
+		Instant expiry = Instant.MIN.plusSeconds(1);
+
+		Jwt jwt = new Jwt(
+				"token",
+				Instant.MIN,
+				expiry,
+				Maps.newHashMap("alg", JwsAlgorithms.RS256),
+				Maps.newHashMap(JwtClaimNames.EXP, expiry));
+
+		JwtAccessTokenVerifier verifier = new JwtAccessTokenVerifier();
+
+		assertThatThrownBy(() -> verifier.verify(jwt.getClaims()))
+				.hasMessageContaining("Jwt expired at " + expiry);
+	}
+
+	@Test
+	public void verifyWhenJwtIsTooEarlyThenErrorMessageIndicatesNotBeforeTime() {
+		Instant oneHourFromNow = Instant.now().plusSeconds(3600);
+
+		Jwt jwt = new Jwt(
+				"token",
+				Instant.MIN,
+				oneHourFromNow,
+				Maps.newHashMap("alg", JwsAlgorithms.RS256),
+				Maps.newHashMap(JwtClaimNames.NBF, oneHourFromNow));
+
+		JwtAccessTokenVerifier verifier = new JwtAccessTokenVerifier();
+
+		assertThatThrownBy(() -> verifier.verify(jwt.getClaims()))
+				.hasMessageContaining("Jwt used before " + oneHourFromNow);
+	}
+}


### PR DESCRIPTION
The error messages in JwtAccessTokenVerifier inadvertently used the
wrong placeholder, {} instead of %s.

Fixes: gh-32